### PR TITLE
Add TerraGuide support section

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
         <li><a href="#features" class="hover:text-indigo-600">Features</a></li>
         <li><a href="#gallery" class="hover:text-indigo-600">Gallery</a></li>
         <li><a href="#feature-pitch" class="hover:text-indigo-600">Offline Automation</a></li>
+        <li><a href="#terraguide" class="hover:text-indigo-600">TerraGuide Support</a></li>
         <li><a href="#contact" class="hover:text-indigo-600">Contact</a></li>
       </ul>
       <div class="flex items-center">
@@ -39,6 +40,7 @@
       <a href="#features" class="block px-6 py-3 border-b hover:bg-gray-100">Features</a>
       <a href="#gallery" class="block px-6 py-3 border-b hover:bg-gray-100">Gallery</a>
       <a href="#feature-pitch" class="block px-6 py-3 border-b hover:bg-gray-100">n8n Pitch</a>
+      <a href="#terraguide" class="block px-6 py-3 border-b hover:bg-gray-100">TerraGuide Support</a>
       <a href="#contact" class="block px-6 py-3 hover:bg-gray-100">Contact</a>
     </div>
   </header>
@@ -204,6 +206,19 @@
         <img src="assets/feature-pitch-n8n-mining.png" alt="n8n event-driven orchestration" class="mx-auto max-w-full rounded shadow-lg">
         <p class="mt-6 text-lg text-gray-600">
           Seamlessly integrate offline AI assistants with real-time n8n workflows to drive efficiency in mining operations, even where networks fail.
+        </p>
+      </div>
+    </section>
+
+    <!-- TerraGuide Support -->
+    <section id="terraguide" class="py-16 bg-white">
+      <div class="container mx-auto px-6 max-w-3xl text-center">
+        <h2 class="text-3xl font-semibold mb-6">TerraGuide Support</h2>
+        <p class="text-lg text-gray-600 mb-4">
+          TerraGuide™ coordinates rescue operations with on-device AI, offline maps, and mesh networking to keep teams connected without cell coverage.
+        </p>
+        <p class="text-lg text-gray-600">
+          Need help? Email us at <a href="mailto:hi@offlyn.ai" class="text-indigo-600 hover:underline">hi@offlyn.ai</a>.
         </p>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add navigation link and mobile menu entry for TerraGuide support
- introduce TerraGuide Support section with description and support email

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68912d5dc6e88320afa9302475415e6d