### PR TITLE
Add TerraGuide privacy policy section and links

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         <li><a href="#gallery" class="hover:text-indigo-600">Gallery</a></li>
         <li><a href="#feature-pitch" class="hover:text-indigo-600">Offline Automation</a></li>
         <li><a href="#terraguide" class="hover:text-indigo-600">TerraGuide Support</a></li>
+        <li><a href="#terraguide-privacy" class="hover:text-indigo-600">TerraGuide Privacy</a></li>
         <li><a href="#contact" class="hover:text-indigo-600">Contact</a></li>
       </ul>
       <div class="flex items-center">
@@ -41,6 +42,7 @@
       <a href="#gallery" class="block px-6 py-3 border-b hover:bg-gray-100">Gallery</a>
       <a href="#feature-pitch" class="block px-6 py-3 border-b hover:bg-gray-100">n8n Pitch</a>
       <a href="#terraguide" class="block px-6 py-3 border-b hover:bg-gray-100">TerraGuide Support</a>
+      <a href="#terraguide-privacy" class="block px-6 py-3 border-b hover:bg-gray-100">TerraGuide Privacy</a>
       <a href="#contact" class="block px-6 py-3 hover:bg-gray-100">Contact</a>
     </div>
   </header>
@@ -223,6 +225,18 @@
       </div>
     </section>
 
+    <!-- TerraGuide Privacy Policy -->
+    <section id="terraguide-privacy" class="py-16 bg-gray-50">
+      <div class="container mx-auto px-6 max-w-3xl">
+        <h2 class="text-3xl font-semibold text-center mb-6">TerraGuide Privacy Policy</h2>
+        <p class="mb-4">TerraGuide operates completely offline and does not collect personal data. Any information you enter remains on your device to support app functionality.</p>
+        <p class="mb-4">We do not transmit or store your data on our servers. Diagnostic logs stay local and are deleted when you remove the app.</p>
+        <p class="mb-4">We never share your information with third parties. You may request deletion of any support communications by contacting us.</p>
+        <p class="mb-4">Contact: <a href="mailto:hi@offlyn.ai" class="text-indigo-600 hover:underline">hi@offlyn.ai</a></p>
+        <p class="text-sm text-gray-600">Last updated: August 15, 2024</p>
+      </div>
+    </section>
+
     <!-- Contact -->
     <section id="contact" class="bg-gray-100 py-16">
       <div class="container mx-auto px-6 max-w-lg">
@@ -250,7 +264,7 @@
     <div class="container mx-auto px-6 flex flex-col md:flex-row items-center justify-between">
       <p class="text-gray-600">© 2025 offlyn.ai. All rights reserved.</p>
       <div class="space-x-4 mt-4 md:mt-0">
-        <a href="#" class="text-gray-600 hover:text-indigo-600">Privacy</a>
+        <a href="#terraguide-privacy" class="text-gray-600 hover:text-indigo-600">Privacy</a>
         <a href="#" class="text-gray-600 hover:text-indigo-600">Terms</a>
         <a href="#" class="text-gray-600 hover:text-indigo-600">Contact</a>
       </div>


### PR DESCRIPTION
## Summary
- add TerraGuide privacy policy section describing data practices
- link privacy policy from main nav, mobile menu, and footer

## Testing
- `npx -y htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68913cb8d6a88320a249b8c1b0126ec5